### PR TITLE
src/thread/context.hpp: fix to build with boost 1.62 

### DIFF
--- a/include/fc/rpc/state.hpp
+++ b/include/fc/rpc/state.hpp
@@ -6,7 +6,7 @@
 namespace fc { namespace rpc {
    struct request
    {
-      std::string         jsonrpc = "2.0";
+      std::string         jsonrpc;
       optional<uint64_t>  id;
       std::string         method;
       variants            params;

--- a/src/thread/context.hpp
+++ b/src/thread/context.hpp
@@ -97,7 +97,7 @@ namespace fc {
     }
 
     context( fc::thread* t) :
-#if BOOST_VERSION >= 105600 && BOOST_VERSION <= 106100 
+#if BOOST_VERSION >= 105600
      my_context(nullptr),
 #elif BOOST_VERSION >= 105300
      my_context(new bc::fcontext_t),


### PR DESCRIPTION
This change was all it took to build fc against libboost-all-dev 1.62.0.1 (debian stable).

See also bitshares/bitshares-fc#5