### PR TITLE
Fix ifdef so fc builds without warning when readline is not configured

### DIFF
--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -164,21 +164,20 @@ char* my_generator(const char* text, int state)
    return ((char *)NULL);
 }
 
-
+#ifdef HAVE_READLINE
 static char** cli_completion( const char * text , int start, int end)
 {
    char **matches;
    matches = (char **)NULL;
 
-#ifdef HAVE_READLINE
    if (start == 0)
       matches = rl_completion_matches ((char*)text, &my_generator);
    else
       rl_bind_key('\t',rl_abort);
-#endif
 
    return (matches);
 }
+#endif
 
 
 void cli::getline( const fc::string& prompt, fc::string& line)


### PR DESCRIPTION
I tested locally by undefining `HAVE_READLINE` before `cli_completion`.

It produced an error as expected. Post patch, the error is gone and the build is successful.